### PR TITLE
jakub_bugfixes -> master

### DIFF
--- a/keepvariable/keepvariable_core.py
+++ b/keepvariable/keepvariable_core.py
@@ -415,7 +415,7 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
         field_to_sort_by: Optional[str] = None,
         asc=True,
         paginate: Optional[tuple[int, int]] = None,
-        ignored_keywords: list = None,
+        ignored_keywords: list[str] = None,
         **kwargs,
     ) -> dict[str, dict]:
         """Simplified alternative to RedisSearch. Allows to search and sort by values of specified fields.
@@ -433,13 +433,14 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
         :return: [('jobs:43', job_dict), ...]
         :rtype: list[tuple]
         """
-        if ignored_keywords is None:
-            ignored_keywords = ["index", "pk", "lock"]
 
-        def occurence_of_ignored_keywords(record_name, ignored_keywords):
-            """Checks validity of filtered records - omits ignored_keywords pk, lock, ..."""
+        def occurence_of_ignored_keywords(record_name: str, ignored_keywords: list[str]) -> bool:
+            """Check validity of filtered records - omit ignored_keywords: pk, lock, ..."""
             are_ignored_keywords_occuring = any(x in record_name for x in ignored_keywords)
             return (are_ignored_keywords_occuring)
+
+        if ignored_keywords is None:
+            ignored_keywords = ["index", "pk", "lock"]
 
         found_records: list[tuple[str, dict]] = [
             (record_name, self.decode_loaded_value(value))
@@ -451,8 +452,8 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
         if tag_params is not None:
             for field, values in tag_params.items():
                 found_records = [
-                    (job_id, job) for job_id, job in found_records
-                    if job.get(field) and job.get(field) in values
+                    (record_id, record) for record_id, record in found_records
+                    if record.get(field) and record.get(field) in values
                 ]
 
         # TEXT search
@@ -461,8 +462,8 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
                 for value in values:
                     # E.g. value = "QUEU", job.get(field) = "QUEUED"
                     found_records = {
-                        (job_id, job) for job_id, job in found_records
-                        if job.get(field) and value in job.get(field)
+                        (record_id, record) for record_id, record in found_records
+                        if record.get(field) and value in record.get(field)
                     }
 
         if field_to_sort_by:

--- a/keepvariable/keepvariable_core.py
+++ b/keepvariable/keepvariable_core.py
@@ -14,7 +14,7 @@ from redis.client import Pipeline as RedisPipeline
 from redis.commands.search.query import Query
 from redis.lock import Lock as RedisLock
 
-from keepvariable.utils import access_element_by_path, parse_path_to_stack
+from keepvariable.utils import access_element_by_path
 
 
 def get_definition(jump_frames, *args, **kwargs):
@@ -191,7 +191,9 @@ class AbstractKeepVariableServer(ABC):
 
         if isinstance(value, type(None)):
             value = {"object_type": "NoneType"}  # Redis does not natively support None values
-        elif isinstance(value, list) or isinstance(value, bool) or isinstance(value, dict) or isinstance(value, int) or isinstance(value, float):
+        elif isinstance(value, list) or isinstance(value, bool) or isinstance(
+            value, dict
+        ) or isinstance(value, int) or isinstance(value, float):
             value = json.dumps(value)
         elif isinstance(value, pd.DataFrame):
             value = self._json_serialize_dataframe(value)
@@ -403,24 +405,17 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
 
         self.set(name, json_obj)
 
-        # for json_xpath, value in params.items():
-        #     element, last_element, last_index = self._extract_object_from_path(name, json_xpath)
-        #     if last_index:
-        #         element[last_element][last_index] = value
-        #     else:
-        #         element[last_element] = value
-
     def query(
         self,
         *,
         text_params: Optional[dict[str, tuple]] = None,
         tag_params: Optional[dict[str, tuple]] = None,
         entity_key: str,
-        index_name: str="index",
+        index_name: str = "index",
         field_to_sort_by: Optional[str] = None,
         asc=True,
         paginate: Optional[tuple[int, int]] = None,
-        ignored_keywords: list = ["index","pk","lock"],
+        ignored_keywords: list = None,
         **kwargs,
     ) -> dict[str, dict]:
         """Simplified alternative to RedisSearch. Allows to search and sort by values of specified fields.
@@ -438,16 +433,19 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
         :return: [('jobs:43', job_dict), ...]
         :rtype: list[tuple]
         """
+        if ignored_keywords is None:
+            ignored_keywords = ["index", "pk", "lock"]
+
         def occurence_of_ignored_keywords(record_name, ignored_keywords):
-            """checks validity of filtered records - omits ignored_keywords pk, lock, ..."""
-            
-            are_ignored_keywords_occuring=any([x in record_name for x in ignored_keywords])
-            return(are_ignored_keywords_occuring)
-            
-            
+            """Checks validity of filtered records - omits ignored_keywords pk, lock, ..."""
+            are_ignored_keywords_occuring = any(x in record_name for x in ignored_keywords)
+            return (are_ignored_keywords_occuring)
+
         found_records: list[tuple[str, dict]] = [
-            (record_name, self.decode_loaded_value(value)) for record_name, value in self.storage.items() if entity_key in record_name and not occurence_of_ignored_keywords(record_name,ignored_keywords)
-          ]  # e.g. [('jobs:43', job_dict), ...]
+            (record_name, self.decode_loaded_value(value))
+            for record_name, value in self.storage.items() if entity_key in record_name and
+            not occurence_of_ignored_keywords(record_name, ignored_keywords)
+        ]  # e.g. [('jobs:43', job_dict), ...]
 
         # TAG search
         if tag_params is not None:
@@ -516,59 +514,6 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
         self.set(name, json_obj)
         return array_length
 
-    def _extract_object_from_path(self, name: str, path: str) -> tuple[Any, str, Optional[int]]:
-        """Recursively traverses a JSON document under 'name' to access the object defined by the 'path' argument.
-
-        :param name: key under which a JSON document is stored
-        :type name: str
-        :param path: Redis JSON path string e.g. "job.nodes[2].status"
-        :type path: str
-        :return: tuple[referenced object, key, index]
-        :rtype: tuple[dict, str, int]
-
-        As Python does not have pointers, we have to trick it by passing a reference.
-        We're returning a reference to the object 1 level above the final one dictated by the 'path' argument
-        Additionally, we are returning the key to the last value we want to access
-        And the index if that value is actually a list, so we can access that list
-        We can use these return values to access object described by 'path' in the original function
-
-        tuple[referenced_object, key, index] --> referenced_object[key][index] = ...
-        """
-        # Parsing sequence from 'path' string
-        # name = "cache"
-        # path = "$.A.B[2].C.D[5]"
-        # elements = ["$", "A", "B[2]", "C", "D[5]"]
-        # element_list = ["cache", "A", "B", "C", "D"]
-        # index_list = [None, None, 2, None, 5]
-        # Then iterate over pairs of both lists and recurrently dive into nested objects
-
-        # Parsing logic
-        elements = path.split(".")
-        pattern = r"\[(\d+)\]"  # Find any "[*]" group where * is one or more digits
-        element_list: list[str] = []
-        index_list: list[Optional[int]] = []
-        for element in elements:
-            if match := re.search(pattern, element):
-                group = match.group()
-                index_list.append(int(group[1:-1]))  # transform "[2]" -> 2
-                element_list.append(element.split("[")[0])  # transform "B[2]" -> "B"
-            else:
-                index_list.append(None)
-                element_list.append(element)
-
-        root = element_list.index("$")
-        element_list[root] = name
-
-        # Traversing logic
-        nested_object = self.storage
-        for element, index in zip(element_list[:-1], index_list[:-1]):
-            if index is not None:
-                nested_object = nested_object[element][index]
-            else:
-                nested_object = nested_object[element]
-
-        return nested_object, element_list[-1], index_list[-1]
-
     def scan(self, match_string: str, *args, **kwargs) -> list[str]:
         """Find saved keys, matching their name with a given glob-style pattern. This command does not block the server, as it is based on a cursor-style iterator.
 
@@ -588,7 +533,8 @@ class KeepVariableDummyRedisServer(AbstractKeepVariableServer):
 
 class KeepVariableRedisServer(AbstractKeepVariableServer):
     def __init__(
-        self, host="localhost", port=6379, db=0, username='default', password: Optional[str] = None
+        self, host: str = "localhost", port: int = 6379, db: int = 0, username: str = 'default',
+        password: Optional[str] = None
     ):
         self.host: str = host
         self.port: int = port
@@ -621,7 +567,7 @@ class KeepVariableRedisServer(AbstractKeepVariableServer):
     def set(
         self, key: str, value: str, additional_params: Optional[dict] = None, *,
         pipeline: Optional[RedisPipeline] = None
-    ):
+    ) ->:
         if additional_params is None:
             additional_params = {}
 
@@ -676,8 +622,9 @@ class KeepVariableRedisServer(AbstractKeepVariableServer):
 
     def query(
         self, *, text_params: Optional[dict[str, tuple]] = None,
-        tag_params: Optional[dict[str, tuple]] = None, entity_key: str, index_name: str="index",
-        field_to_sort_by: Optional[str] = None, asc=True, paginate: Optional[tuple[int, int]] = None, **kwargs
+        tag_params: Optional[dict[str, tuple]] = None, entity_key: str, index_name: str = "index",
+        field_to_sort_by: Optional[str] = None, asc=True,
+        paginate: Optional[tuple[int, int]] = None, **kwargs
     ) -> dict:
         """Simplified wrapper to RedisSearch. Allows to search and sort by a value of Redis TAG/TEXT fields.
 
@@ -726,8 +673,8 @@ class KeepVariableRedisServer(AbstractKeepVariableServer):
         if paginate:
             query_object.paging(*paginate)
 
-        assert len(entity_key)>0 #entity needs to be specified
-        index_key=entity_key+":"+index_name
+        assert len(entity_key) > 0  #entity needs to be specified
+        index_key = entity_key + ":" + index_name
         job_docs: list = self.redis.ft(index_key).search(query_object).docs
         return {job_doc.id: self.decode_loaded_value(job_doc.json) for job_doc in job_docs}
 

--- a/keepvariable/utils.py
+++ b/keepvariable/utils.py
@@ -1,0 +1,114 @@
+import re
+from typing import Any, Optional, Union
+
+def access_element_by_path(json_obj: dict, json_path: str) -> tuple[Optional[object], Optional[Union[str, int]]]:
+    path_stack = parse_path_to_stack(json_path)
+    current_obj = json_obj
+
+    if not path_stack:
+        return None, None
+
+    for key in path_stack[:-1]:
+        current_obj = current_obj[key]
+
+    final_key = path_stack[-1] if path_stack else None
+    return current_obj, final_key  # Returning parent object and final key or index
+
+def parse_path_to_stack(json_path: str) -> list[Union[int, str]]:
+    elements = json_path.split(".")
+    pattern = r"\[(\d+)\]"  # Find any number consisting of 1 or more digits, enclosed by []
+    stack = []
+    for elem in elements[1:]:
+        key = elem.split("[")[0]
+        stack.append(key)
+
+        matches = re.findall(pattern, elem)
+        for match in matches:
+            index = int(match)
+            stack.append(index)
+
+    return stack
+
+# def access_element_by_path(json_obj: dict, json_path: str):
+#     stack: list = parse_path_to_stack(json_path)
+
+    # curr_obj = json_obj
+    # while len(stack) > 1:
+    #     key = stack.pop(0)
+    #     if stack and isinstance(stack[0], int):
+    #         index = stack.pop(0)
+    #         curr_obj = curr_obj.setdefault(key, [])[index]
+    #     elif isinstance(stack[0], str):
+    #         curr_obj = curr_obj.setdefault(key, {})
+
+    # final_key = stack.pop(0)
+    # return curr_obj, final_key  # Returning parent object and final key or index
+
+# def parse_path_to_stack(json_path: str):
+#     elements = json_path.split(".")
+#     pattern = r"\[(\d+)\]"  # Find any "[*]" group where * is one or more digits
+#     stack = []
+#     for elem in elements:
+#         match = re.find(pattern, elem)
+#         if match:
+#             key, index_str = elem.split("[")
+#             index = int(index_str[:-1])
+#             stack.extend([key, index])
+#         else:
+#             stack.append(elem)
+#     return stack
+
+def _extract_object_from_path(self, obj: Union[list, dict], name: str, path: str) -> tuple[Any, str, Optional[int]]:
+    """Recursively traverses a JSON document under 'name' to access the object defined by the 'path' argument.
+
+    :param obj: key under which a JSON document is stored
+    :type obj: list | dict
+    :param name: key under which a JSON document is stored
+    :type name: str
+    :param path: Redis JSON path string e.g. "job.nodes[2].status"
+    :type path: str
+    :return: tuple[referenced object, key, index]
+    :rtype: tuple[dict, str, int]
+
+    As Python does not have pointers, we have to trick it by passing a reference.
+    We're returning a reference to the object 1 level above the final one dictated by the 'path' argument
+    Additionally, we are returning the key to the last value we want to access
+    And the index if that value is actually a list, so we can access that list
+    We can use these return values to access object described by 'path' in the original function
+
+    tuple[referenced_object, key, index] --> referenced_object[key][index] = ...
+    """
+    # Parsing sequence from 'path' string
+    # name = "cache"
+    # path = "$.A.B[2].C.D[5]"
+    # elements = ["$", "A", "B[2]", "C", "D[5]"]
+    # element_list = ["cache", "A", "B", "C", "D"]
+    # index_list = [None, None, 2, None, 5]
+    # Then iterate over pairs of both lists and recurrently dive into nested objects
+
+    # Parsing logic
+    elements = path.split(".")
+    pattern = r"\[(\d+)\]"  # Find any "[*]" group where * is one or more digits
+    element_list: list[str] = []
+    index_list: list[Optional[int]] = []
+    for element in elements:
+        if match := re.search(pattern, element):
+            group = match.group()
+            index_list.append(int(group[1:-1]))  # transform "[2]" -> 2
+            element_list.append(element.split("[")[0])  # transform "B[2]" -> "B"
+        else:
+            index_list.append(None)
+            element_list.append(element)
+
+    root = element_list.index("$")
+    element_list[root] = name
+
+    # Traversing logic
+    nested_object = obj
+    for element, index in zip(element_list[:-1], index_list[:-1]):
+        if index is not None:
+            nested_object = nested_object[element][index]
+        else:
+            nested_object = nested_object[element]
+
+    return nested_object, element_list[-1], index_list[-1]

--- a/keepvariable/utils.py
+++ b/keepvariable/utils.py
@@ -34,7 +34,7 @@ def access_element_by_path(json_obj: Union[dict, list], json_path: str) -> tuple
     try:
         for key in path_stack[:-1]:
             current_obj = current_obj[key]
-        final_key = path_stack[-1] if path_stack else None
+        final_key = path_stack[-1]
     except (AttributeError, IndexError) as e:
         raise IncorrectPathError(f"Path '{json_path}' could not be accessed") from e
 

--- a/keepvariable/utils.py
+++ b/keepvariable/utils.py
@@ -1,114 +1,70 @@
 import re
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
-def access_element_by_path(json_obj: dict, json_path: str) -> tuple[Optional[object], Optional[Union[str, int]]]:
-    path_stack = parse_path_to_stack(json_path)
-    current_obj = json_obj
 
-    if not path_stack:
-        return None, None
+class IncorrectPathError(Exception): ...
 
-    for key in path_stack[:-1]:
-        current_obj = current_obj[key]
 
-    final_key = path_stack[-1] if path_stack else None
-    return current_obj, final_key  # Returning parent object and final key or index
+def access_element_by_path(json_obj: Union[dict, list], json_path: str) -> tuple[Optional[object], Optional[Union[str, int]]]:
+    """Traverse a JSON document under 'name' to access the object defined by the 'path' argument.
 
-def parse_path_to_stack(json_path: str) -> list[Union[int, str]]:
-    elements = json_path.split(".")
-    pattern = r"\[(\d+)\]"  # Find any number consisting of 1 or more digits, enclosed by []
-    stack = []
-    for elem in elements[1:]:
-        key = elem.split("[")[0]
-        stack.append(key)
-
-        matches = re.findall(pattern, elem)
-        for match in matches:
-            index = int(match)
-            stack.append(index)
-
-    return stack
-
-# def access_element_by_path(json_obj: dict, json_path: str):
-#     stack: list = parse_path_to_stack(json_path)
-
-    # curr_obj = json_obj
-    # while len(stack) > 1:
-    #     key = stack.pop(0)
-    #     if stack and isinstance(stack[0], int):
-    #         index = stack.pop(0)
-    #         curr_obj = curr_obj.setdefault(key, [])[index]
-    #     elif isinstance(stack[0], str):
-    #         curr_obj = curr_obj.setdefault(key, {})
-
-    # final_key = stack.pop(0)
-    # return curr_obj, final_key  # Returning parent object and final key or index
-
-# def parse_path_to_stack(json_path: str):
-#     elements = json_path.split(".")
-#     pattern = r"\[(\d+)\]"  # Find any "[*]" group where * is one or more digits
-#     stack = []
-#     for elem in elements:
-#         match = re.find(pattern, elem)
-#         if match:
-#             key, index_str = elem.split("[")
-#             index = int(index_str[:-1])
-#             stack.extend([key, index])
-#         else:
-#             stack.append(elem)
-#     return stack
-
-def _extract_object_from_path(self, obj: Union[list, dict], name: str, path: str) -> tuple[Any, str, Optional[int]]:
-    """Recursively traverses a JSON document under 'name' to access the object defined by the 'path' argument.
-
-    :param obj: key under which a JSON document is stored
+    :param obj: reference to the traversed object
     :type obj: list | dict
-    :param name: key under which a JSON document is stored
-    :type name: str
-    :param path: Redis JSON path string e.g. "job.nodes[2].status"
+    :param path: Redis JSON path string e.g. "$.job.nodes[2].status"
     :type path: str
-    :return: tuple[referenced object, key, index]
-    :rtype: tuple[dict, str, int]
+    :return: tuple[referenced object, key]
+    :rtype: tuple[Optional[object], Optional[Union[str, int]]]
 
     As Python does not have pointers, we have to trick it by passing a reference.
     We're returning a reference to the object 1 level above the final one dictated by the 'path' argument
-    Additionally, we are returning the key to the last value we want to access
-    And the index if that value is actually a list, so we can access that list
+    Additionally, we are returning the key (or index) to the last value we want to access
     We can use these return values to access object described by 'path' in the original function
 
-    tuple[referenced_object, key, index] --> referenced_object[key][index] = ...
+    tuple[referenced_object, key] --> referenced_object[key] = ...
+
+    If referenced object is None, overwrite the json_obj itself, as the reference cannot be
+    constructed for outermost object.
     """
-    # Parsing sequence from 'path' string
-    # name = "cache"
-    # path = "$.A.B[2].C.D[5]"
-    # elements = ["$", "A", "B[2]", "C", "D[5]"]
-    # element_list = ["cache", "A", "B", "C", "D"]
-    # index_list = [None, None, 2, None, 5]
-    # Then iterate over pairs of both lists and recurrently dive into nested objects
+    path_stack = parse_path_to_stack(json_path)
+    current_obj = json_obj
 
-    # Parsing logic
-    elements = path.split(".")
-    pattern = r"\[(\d+)\]"  # Find any "[*]" group where * is one or more digits
-    element_list: list[str] = []
-    index_list: list[Optional[int]] = []
-    for element in elements:
-        if match := re.search(pattern, element):
-            group = match.group()
-            index_list.append(int(group[1:-1]))  # transform "[2]" -> 2
-            element_list.append(element.split("[")[0])  # transform "B[2]" -> "B"
-        else:
-            index_list.append(None)
-            element_list.append(element)
+    if not path_stack: # With the empty stack, no reference can be passed - object must be overwritten directly
+        return None, None
 
-    root = element_list.index("$")
-    element_list[root] = name
+    try:
+        for key in path_stack[:-1]:
+            current_obj = current_obj[key]
+        final_key = path_stack[-1] if path_stack else None
+    except (AttributeError, IndexError) as e:
+        raise IncorrectPathError(f"Path '{json_path}' could not be accessed") from e
 
-    # Traversing logic
-    nested_object = obj
-    for element, index in zip(element_list[:-1], index_list[:-1]):
-        if index is not None:
-            nested_object = nested_object[element][index]
-        else:
-            nested_object = nested_object[element]
+    return current_obj, final_key  # Returning parent object and final key or index
 
-    return nested_object, element_list[-1], index_list[-1]
+def parse_path_to_stack(json_path: str) -> list[Union[int, str]]:
+    """Deconstruct path string into a stack of references allowing traversal.
+
+    :param json_path: Redis JSON path string e.g. "$.job.nodes[2].status"
+    :type json_path: str
+    :return: ["$", "job", "nodes", 2, "status"]
+    :rtype: list[Union[int, str]]
+
+    e.g. "$.job.nodes[2].status" -> ["$", "job", "nodes", 2, "status"]
+    """
+    elements = json_path.split(".")
+    pattern = r"\[(\d+)\]"  # Find any number consisting of 1 or more digits, enclosed by []
+    stack = []
+
+    try:
+        for element in elements:
+            key = element.split("[")[0]
+            if key != "$": # Omit root element
+                stack.append(key)
+
+            matches = re.findall(pattern, element)
+            for match in matches:
+                index = int(match)
+                stack.append(index)
+    except (AttributeError, IndexError) as e:
+        raise IncorrectPathError(f"Path '{json_path}' could not be accessed") from e
+
+    return stack

--- a/keepvariable/utils.py
+++ b/keepvariable/utils.py
@@ -64,7 +64,7 @@ def parse_path_to_stack(json_path: str) -> list[Union[int, str]]:
             for match in matches:
                 index = int(match)
                 stack.append(index)
-    except (AttributeError, IndexError) as e:
+    except (AttributeError, IndexError, TypeError) as e:
         raise IncorrectPathError(f"Path '{json_path}' could not be accessed") from e
 
     return stack


### PR DESCRIPTION
This PR introduces:
- Now `DummyRedisServer` persists only strings, meaning that JSON files are saved as true JSONs and not Python objects (applicable for any functionality mimicking `RedisJSON`-powered methods, like `query`, `arrappend`, `arrlen` etc.
- Traversal logic modified and moved to a separate file. 
- Removed slicing bug in `DummyRedisServer` `query()` method
- Code reformatted and cleaned